### PR TITLE
Set default fallback for getSerialized call in case spam file is empty

### DIFF
--- a/Akismet/AkismetController.php
+++ b/Akismet/AkismetController.php
@@ -144,7 +144,7 @@ class AkismetController extends Controller
                     ),
                     array_filter(
                         $this->storage
-                            ->getSerialized(Path::assemble($formset, $filename))
+                            ->getSerialized(Path::assemble($formset, $filename), collect([]))
                             ->toArray()
                     )
                 );


### PR DESCRIPTION
Fixes #21 